### PR TITLE
Custom ObjectInputStream so we can try the threadlocal class loader

### DIFF
--- a/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
+++ b/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
@@ -15,8 +15,10 @@ import scala.util.Try
  * Play's test/run modes.
  */
 class GenericCodecObjectInputStream(classTag: ClassTag[_], in: InputStream) extends ObjectInputStream(in) {
-  val classTagClassLoader = classTag.runtimeClass.getClassLoader
-  val threadLocalClassLoader = Thread.currentThread().getContextClassLoader
+
+  private def classTagClassLoader = classTag.runtimeClass.getClassLoader
+  private def threadLocalClassLoader = Thread.currentThread().getContextClassLoader
+
   override protected def resolveClass(desc: ObjectStreamClass): Class[_] = {
     Try(classTagClassLoader.loadClass(desc.getName)).
       orElse(Try(super.resolveClass(desc))).

--- a/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
+++ b/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
@@ -1,0 +1,25 @@
+package shade.memcached
+
+import java.io.{ObjectStreamClass, InputStream, ObjectInputStream}
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+/**
+ * Object input stream which tries the thread local class loader.
+ *
+ * Thread Local class loader is used by SBT to avoid polluting system class loader when
+ * running different tasks.
+ *
+ * This allows deserialisation of classes from subprojects during something like
+ * Play's test/run modes.
+ */
+class GenericCodecObjectInputStream(classTag: ClassTag[_], in: InputStream) extends ObjectInputStream(in) {
+  val classTagClassLoader = classTag.runtimeClass.getClassLoader
+  val threadLocalClassLoader = Thread.currentThread().getContextClassLoader
+  override protected def resolveClass(desc: ObjectStreamClass): Class[_] = {
+    Try(classTagClassLoader.loadClass(desc.getName)).
+      orElse(Try(super.resolveClass(desc))).
+      getOrElse(super.resolveClass(desc))
+  }
+}

--- a/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
+++ b/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
@@ -20,6 +20,6 @@ class GenericCodecObjectInputStream(classTag: ClassTag[_], in: InputStream) exte
   override protected def resolveClass(desc: ObjectStreamClass): Class[_] = {
     Try(classTagClassLoader.loadClass(desc.getName)).
       orElse(Try(super.resolveClass(desc))).
-      getOrElse(super.resolveClass(desc))
+      getOrElse(threadLocalClassLoader.loadClass(desc.getName))
   }
 }


### PR DESCRIPTION
Thread Local class loader is used by SBT to avoid polluting system class loader when running different tasks.

This allows deserialisation of classes from subprojects during something like Play's test/run modes.

For more details, see http://stackoverflow.com/questions/12496939/sbt-play2-multi-project-setup-does-not-include-dependant-projects-in-classpath-i