### PR TITLE
Use ExecutionContext implicitly.

### DIFF
--- a/src/test/scala/shade/tests/MemcachedTestHelpers.scala
+++ b/src/test/scala/shade/tests/MemcachedTestHelpers.scala
@@ -22,7 +22,9 @@ trait MemcachedTestHelpers extends MemcachedCodecs {
       operationTimeout = opTimeout.getOrElse(defaultConfig.operationTimeout)
     )
 
-    Memcached(config, global)
+    config match {
+      case Configuration(ad, au, kp, pr, fm, ow) => Memcached(ad, au, kp, pr, fm, ow)
+    }
   }
 
   def withFakeMemcached[T](cb: Memcached => T): T = {


### PR DESCRIPTION
Could you please make the Memcached#apply to use ExecutionContext implicitly?

I want to use your Memcached like `Memcached("127.0.0.1:11211")`.
What I did was just overloaded the apply method.


Thanks for your good work.