### PR TITLE
Stable version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,9 @@ name := "shade"
 
 organization := "com.bionicspirit"
 
-version := "1.7.0-SNAPSHOT"
+version := "1.7.0"
 
-scalaVersion := "2.10.4"
-
-crossScalaVersions := Seq("2.10.4", "2.11.0")
+scalaVersion := "2.11.7"
 
 compileOrder in ThisBuild := CompileOrder.JavaThenScala
 


### PR DESCRIPTION
Remove SNAPSHOT and clean up cross-compiling.  We're all good on Scala 2.11 now.

I did notice some of the stock unit tests from the original alexandru/shade project did not pass, which is a concern, but I'll leave that to the author. :-)