### PR TITLE
Add a Codec for Array[Byte] in BaseCodecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: scala
 scala:
+  - 2.10.6
   - 2.11.7
 jdk:
   - openjdk7
+  - oraclejdk8
 services:
   - memcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+sudo: false
 scala:
   - 2.10.6
   - 2.11.7
@@ -7,3 +8,16 @@ jdk:
   - oraclejdk8
 services:
   - memcache
+cache:
+  directories:
+  - $HOME/.sbt/0.13
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/cache
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2
+before_cache:
+  - du -h -d 1 $HOME/.ivy2/
+  - du -h -d 2 $HOME/.sbt/
+  - find $HOME/.sbt -name "*.lock" -type f -delete
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
+

--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,8 @@ publishArtifact in Test := false
 
 pomIncludeRepository := { _ => false } // removes optional dependencies
 
+scalariformSettings
+
 pomExtra in ThisBuild :=
   <url>https://github.com/alexandru/shade</url>
     <licenses>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.1
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")

--- a/src/main/scala/shade/inmemory/InMemoryCache.scala
+++ b/src/main/scala/shade/inmemory/InMemoryCache.scala
@@ -2,11 +2,10 @@ package shade.inmemory
 
 import concurrent.duration._
 import monifu.concurrent.atomic.AtomicAny
-import scala.concurrent.{Promise, ExecutionContext, Future}
+import scala.concurrent.{ Promise, ExecutionContext, Future }
 import monifu.concurrent.Scheduler
 import scala.annotation.tailrec
 import scala.util.Try
-
 
 trait InMemoryCache extends java.io.Closeable {
   def get[T](key: String): Option[T]
@@ -140,12 +139,10 @@ private[inmemory] final class InMemoryCacheImpl(implicit ec: ExecutionContext) e
         if (stateRef.compareAndSet(currentState, newState)) {
           promise.completeWith(cb)
           future
-        }
-        else
+        } else
           cachedFuture(key, expiry)(cb)
     }
   }
-
 
   def compareAndSet[T](key: String, expected: Option[T], update: T, expiry: Duration): Boolean = {
     val current = stateRef.get
@@ -157,7 +154,6 @@ private[inmemory] final class InMemoryCacheImpl(implicit ec: ExecutionContext) e
       case _ =>
         None
     }
-
 
     if (currentValue != expected)
       false
@@ -220,8 +216,7 @@ private[inmemory] final class InMemoryCacheImpl(implicit ec: ExecutionContext) e
 
         val newState = CacheState(values, firstExpiry)
         ((currentState.maintenancePromise, difference), newState)
-      }
-      else {
+      } else {
         val newState = currentState.copy(maintenancePromise = Promise())
         ((currentState.maintenancePromise, 0), newState)
       }
@@ -229,7 +224,6 @@ private[inmemory] final class InMemoryCacheImpl(implicit ec: ExecutionContext) e
 
     promise.trySuccess(difference)
   }
-
 
   def size: Int = {
     val ts = System.currentTimeMillis()

--- a/src/main/scala/shade/memcached/Codec.scala
+++ b/src/main/scala/shade/memcached/Codec.scala
@@ -3,7 +3,6 @@ package shade.memcached
 import java.io._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
-import scala.util.Try
 import scala.util.control.NonFatal
 import java.io.Serializable
 

--- a/src/main/scala/shade/memcached/Configuration.scala
+++ b/src/main/scala/shade/memcached/Configuration.scala
@@ -24,15 +24,15 @@ import net.spy.memcached.ops.OperationQueueFactory
  * @param operationTimeout  is the default operation timeout; When the limit is reached, the
  *                          Future responses finish with Failure(TimeoutException)
  *
- * @param opQueueFactory    can be used to customize the operations queue, 
+ * @param opQueueFactory    can be used to customize the operations queue,
  *                          i.e. the queue of operations waiting to be processed by SpyMemcached.
  *                          If `None`, the default SpyMemcached implementation (a bounded ArrayBlockingQueue) is used.
  *
- * @param readQueueFactory  can be used to customize the read queue, 
+ * @param readQueueFactory  can be used to customize the read queue,
  *                          i.e. the queue of Memcached responses waiting to be processed by SpyMemcached.
  *                          If `None`, the default SpyMemcached implementation (an unbounded LinkedBlockingQueue) is used.
  *
- * @param writeQueueFactory can be used to customize the write queue, 
+ * @param writeQueueFactory can be used to customize the write queue,
  *                          i.e. the queue of operations waiting to be sent to Memcached by SpyMemcached.
  *                          If `None`, the default SpyMemcached implementation (an unbounded LinkedBlockingQueue) is used.
  */

--- a/src/main/scala/shade/memcached/FakeMemcached.scala
+++ b/src/main/scala/shade/memcached/FakeMemcached.scala
@@ -1,9 +1,8 @@
 package shade.memcached
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import shade.inmemory.InMemoryCache
-
 
 class FakeMemcached(context: ExecutionContext) extends Memcached {
   private[this] implicit val ec = context

--- a/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
+++ b/src/main/scala/shade/memcached/GenericCodecObjectInputStream.scala
@@ -1,6 +1,6 @@
 package shade.memcached
 
-import java.io.{InputStream, ObjectInputStream, ObjectStreamClass}
+import java.io.{ InputStream, ObjectInputStream, ObjectStreamClass }
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
@@ -14,7 +14,7 @@ import scala.util.control.NonFatal
  * Play's test/run modes.
  */
 class GenericCodecObjectInputStream(classTag: ClassTag[_], in: InputStream)
-  extends ObjectInputStream(in) {
+    extends ObjectInputStream(in) {
 
   private def classTagClassLoader =
     classTag.runtimeClass.getClassLoader

--- a/src/main/scala/shade/memcached/Memcached.scala
+++ b/src/main/scala/shade/memcached/Memcached.scala
@@ -1,7 +1,7 @@
 package shade.memcached
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ExecutionContext, Await, Future}
+import scala.concurrent.{ ExecutionContext, Await, Future }
 
 trait Memcached extends java.io.Closeable {
   /**

--- a/src/main/scala/shade/memcached/MemcachedImpl.scala
+++ b/src/main/scala/shade/memcached/MemcachedImpl.scala
@@ -1,17 +1,16 @@
 package shade.memcached
 
 import internals._
-import concurrent.{Future, ExecutionContext}
-import net.spy.memcached.{FailureMode => SpyFailureMode, _}
-import net.spy.memcached.ConnectionFactoryBuilder.{Protocol => SpyProtocol}
-import net.spy.memcached.auth.{PlainCallbackHandler, AuthDescriptor}
+import concurrent.{ Future, ExecutionContext }
+import net.spy.memcached.{ FailureMode => SpyFailureMode, _ }
+import net.spy.memcached.ConnectionFactoryBuilder.{ Protocol => SpyProtocol }
+import net.spy.memcached.auth.{ PlainCallbackHandler, AuthDescriptor }
 import concurrent.duration._
 import java.util.concurrent.TimeUnit
 import shade.memcached.internals.SuccessfulResult
 import shade.memcached.internals.FailedResult
-import shade.{UnhandledStatusException, CancelledException, TimeoutException}
+import shade.{ UnhandledStatusException, CancelledException, TimeoutException }
 import monifu.concurrent.Scheduler
-
 
 /**
  * Memcached client implementation based on SpyMemcached.
@@ -231,7 +230,8 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
       throw new CancelledException(withoutPrefix(k))
     case FailedResult(k, unhandled) =>
       throw new UnhandledStatusException(
-        "For key %s - %s".format(withoutPrefix(k), unhandled.getClass.getName))
+        "For key %s - %s".format(withoutPrefix(k), unhandled.getClass.getName)
+      )
   }
 
   @inline
@@ -252,8 +252,10 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
   private[this] val prefix = config.keysPrefix.getOrElse("")
   private[this] val instance = {
     if (System.getProperty("net.spy.log.LoggerImpl") == null) {
-      System.setProperty("net.spy.log.LoggerImpl",
-        "shade.memcached.internals.Slf4jLogger")
+      System.setProperty(
+        "net.spy.log.LoggerImpl",
+        "shade.memcached.internals.Slf4jLogger"
+      )
     }
 
     val conn = {
@@ -287,8 +289,11 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
       val withAuth = config.authentication match {
         case Some(credentials) =>
           withTimeout.setAuthDescriptor(
-            new AuthDescriptor(Array("PLAIN"),
-              new PlainCallbackHandler(credentials.username, credentials.password)))
+            new AuthDescriptor(
+              Array("PLAIN"),
+              new PlainCallbackHandler(credentials.username, credentials.password)
+            )
+          )
         case None =>
           withTimeout
       }

--- a/src/main/scala/shade/memcached/internals/PartialResult.scala
+++ b/src/main/scala/shade/memcached/internals/PartialResult.scala
@@ -1,7 +1,7 @@
 package shade.memcached.internals
 
-import util.{Success, Try}
-import concurrent.{Promise, Future}
+import util.{ Success, Try }
+import concurrent.{ Promise, Future }
 import monifu.concurrent.atomic.AtomicAny
 
 sealed trait PartialResult[+T]
@@ -28,5 +28,5 @@ final class MutablePartialResult[T] {
   }
 
   private[this] val _result =
-    AtomicAny(NoResultAvailable : PartialResult[T])
+    AtomicAny(NoResultAvailable: PartialResult[T])
 }

--- a/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
+++ b/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
@@ -1,21 +1,20 @@
 package shade.memcached.internals
 
-import java.net.{SocketAddress, InetSocketAddress}
+import java.net.{ SocketAddress, InetSocketAddress }
 import net.spy.memcached.compat.SpyObject
 import net.spy.memcached.ops._
 import net.spy.memcached._
 import collection.JavaConverters._
-import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.concurrent.{ExecutionContext, Promise, Future}
-import scala.util.{Try, Failure, Success}
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.{ ExecutionContext, Promise, Future }
+import scala.util.{ Try, Failure, Success }
 import scala.util.control.NonFatal
 import net.spy.memcached.auth.AuthThreadMonitor
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
 import java.io.IOException
 import shade.UnhandledStatusException
 import monifu.concurrent.atomic.Atomic
 import monifu.concurrent.Scheduler
-
 
 /**
  * Hooking in the SpyMemcached Internals.
@@ -25,7 +24,7 @@ import monifu.concurrent.Scheduler
  * @param scheduler is for making timeouts work
  */
 class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddress], scheduler: Scheduler)
-  extends SpyObject with ConnectionObserver {
+    extends SpyObject with ConnectionObserver {
 
   require(cf != null, "Invalid connection factory")
   require(addrs != null && addrs.nonEmpty, "Invalid addresses list")
@@ -104,8 +103,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
 
     try {
       blatch.await(timeout, unit)
-    }
-    catch {
+    } catch {
       case e: InterruptedException =>
         throw new RuntimeException("Interrupted waiting for queues", e)
     }
@@ -144,8 +142,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
     if (!shuttingDown.compareAndSet(expect = false, update = true)) {
       getLogger.info("Suppressing duplicate attempt to shut down")
       false
-    }
-    else {
+    } else {
       val baseName: String = mconn.getName
       mconn.setName(baseName + " - SHUTTING DOWN")
 
@@ -153,17 +150,14 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
         if (timeout > 0) {
           mconn.setName(baseName + " - SHUTTING DOWN (waiting)")
           waitForQueues(timeout, unit)
-        }
-        else
+        } else
           true
-      }
-      finally {
+      } finally {
         try {
           mconn.setName(baseName + " - SHUTTING DOWN (telling client)")
           mconn.shutdown()
           mconn.setName(baseName + " - SHUTTING DOWN (informed client)")
-        }
-        catch {
+        } catch {
           case e: IOException =>
             getLogger.warn("exception while shutting down": Any, e: Throwable)
         }
@@ -189,7 +183,8 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
 
         else
           throw new UnhandledStatusException(
-            "%s(%s)".format(opStatus.getClass, opStatus.getMessage))
+            "%s(%s)".format(opStatus.getClass, opStatus.getMessage)
+          )
       }
 
       def gotData(k: String, flags: Int, data: Array[Byte]) {
@@ -222,7 +217,8 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
 
         else
           throw new UnhandledStatusException(
-            "%s(%s)".format(opStatus.getClass, opStatus.getMessage))
+            "%s(%s)".format(opStatus.getClass, opStatus.getMessage)
+          )
       }
 
       def gotData(key: String, cas: Long) {
@@ -249,13 +245,14 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
             case CASExistsStatus =>
               result.tryComplete(Success(SuccessfulResult(key, None)))
             case CASSuccessStatus =>
-              // nothing
+            // nothing
             case failure =>
               result.tryComplete(Success(FailedResult(key, failure)))
           }
         else
           throw new UnhandledStatusException(
-            "%s(%s)".format(opStatus.getClass, opStatus.getMessage))
+            "%s(%s)".format(opStatus.getClass, opStatus.getMessage)
+          )
       }
 
       def gotData(key: String, cas: Long) {
@@ -295,7 +292,8 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
 
         else
           throw new UnhandledStatusException(
-            "%s(%s)".format(opStatus.getClass, opStatus.getMessage))
+            "%s(%s)".format(opStatus.getClass, opStatus.getMessage)
+          )
       }
     })
 
@@ -314,13 +312,14 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
             case CASNotFoundStatus =>
               result.tryComplete(Success(SuccessfulResult(key, None)))
             case CASSuccessStatus =>
-              // nothing
+            // nothing
             case failure =>
               result.tryComplete(Success(FailedResult(key, failure)))
           }
         else
           throw new UnhandledStatusException(
-            "%s(%s)".format(opStatus.getClass, opStatus.getMessage))
+            "%s(%s)".format(opStatus.getClass, opStatus.getMessage)
+          )
       }
 
       def gotData(receivedKey: String, flags: Int, cas: Long, data: Array[Byte]) {
@@ -361,7 +360,8 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
 
         else
           throw new UnhandledStatusException(
-            "%s(%s)".format(opStatus.getClass, opStatus.getMessage))
+            "%s(%s)".format(opStatus.getClass, opStatus.getMessage)
+          )
       }
 
       def gotData(k: String, cas: Long) {
@@ -395,8 +395,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       case msg =>
         try {
           cancelable.cancel()
-        }
-        catch {
+        } catch {
           case NonFatal(_) =>
         }
 

--- a/src/test/scala/shade/testModels/Offer.scala
+++ b/src/test/scala/shade/testModels/Offer.scala
@@ -1,29 +1,28 @@
 package shade.testModels
 
-
 import java.util.UUID
 
 case class Offer(
-  id: Option[Int],
-  name: String,
+    id: Option[Int],
+    name: String,
 
-  advertiser: Advertiser,
-  offerType: String,
+    advertiser: Advertiser,
+    offerType: String,
 
-  liveDeal: LiveDealInfo,
-  creative: OfferCreative,
+    liveDeal: LiveDealInfo,
+    creative: OfferCreative,
 
-  deliveryMechanisms: Seq[String],
+    deliveryMechanisms: Seq[String],
 
-  servedURL: String,
-  realURL: Option[String],
+    servedURL: String,
+    realURL: Option[String],
 
-  // is_active and is_valid
-  isRunning: Boolean,
-  isDynamic: Boolean,
-  isGlobal: Boolean,
+    // is_active and is_valid
+    isRunning: Boolean,
+    isDynamic: Boolean,
+    isGlobal: Boolean,
 
-  countries: Seq[String]
+    countries: Seq[String]
 ) {
 
   def uniqueToken = {

--- a/src/test/scala/shade/testModels/package.scala
+++ b/src/test/scala/shade/testModels/package.scala
@@ -24,14 +24,18 @@ package object testModels {
             Some(703),
             None,
             Some("VA"),
-            Some(511)))),
+            Some(511)
+          )
+        )
+      ),
 
       Some("aac636be-e42b-01d6-449b-6a0c2e5e7b09"),
       Some("something-65"),
       Some("71.89.145.102"),
       None,
       None,
-      Some("us")),
+      Some("us")
+    ),
     List(
       Offer(
         Some(3352251),
@@ -39,20 +43,23 @@ package object testModels {
         Advertiser(
           Some(137),
           Some("something"),
-          "something"),
+          "something"
+        ),
         "cpa",
         LiveDealInfo(
           Some(""),
           None,
           None,
-          None),
+          None
+        ),
 
         OfferCreative(
           "So Many Dresses!",
           "Daily Deals For Moms, Babies and Kids. Up to 90% OFF! Shop Now!",
           Some("Something.com"),
           Some(""),
-          None),
+          None
+        ),
 
         ArrayBuffer("viewnow"),
 
@@ -61,10 +68,13 @@ package object testModels {
         true,
         false,
         false,
-        List("us"))),
+        List("us")
+      )
+    ),
     112,
     true,
-    Some("light-fullscreen"))
+    Some("light-fullscreen")
+  )
 
   val bigInstance2 = Impression(
     "96298b14-1e13-a162-662b-969bd3b41ca4",
@@ -87,18 +97,23 @@ package object testModels {
             Some(703),
             None,
             Some("VA"),
-            Some(511)))),
+            Some(511)
+          )
+        )
+      ),
 
       Some("aac636be-e42b-01d6-449b-6a0c2e5e7b09"),
       Some("something-65"),
       Some("71.89.145.102"),
       None,
       None,
-      Some("us")),
+      Some("us")
+    ),
     List.empty,
     112,
     true,
-    Some("light-fullscreen"))
+    Some("light-fullscreen")
+  )
 
   val contentSeq = Vector(
     ContentPiece.Article(

--- a/src/test/scala/shade/tests/FakeMemcachedSuite.scala
+++ b/src/test/scala/shade/tests/FakeMemcachedSuite.scala
@@ -1,13 +1,11 @@
 package shade.tests
 
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import scala.concurrent.ExecutionContext.Implicits.global
 import shade.testModels.Impression
-import java.io.{ObjectOutputStream, ByteArrayOutputStream}
+import java.io.{ ObjectOutputStream, ByteArrayOutputStream }
 import scala.concurrent.duration._
 import scala.concurrent.Await
-
 
 class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
   implicit val timeout = 5.second
@@ -204,7 +202,6 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
     }
   }
 
-
   test("big-instance-1-manual") {
     withFakeMemcached { cache =>
       val byteOut = new ByteArrayOutputStream()
@@ -221,7 +218,6 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
       assert(inBytes.get.length == byteArray.length)
     }
   }
-
 
   test("big-instance-2") {
     withFakeMemcached { cache =>

--- a/src/test/scala/shade/tests/InMemoryCacheVer2Suite.scala
+++ b/src/test/scala/shade/tests/InMemoryCacheVer2Suite.scala
@@ -1,12 +1,10 @@
 package shade.tests
 
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Future, Await}
+import scala.concurrent.{ Future, Await }
 import shade.inmemory.InMemoryCache
-
 
 class InMemoryCacheVer2Suite extends FunSuite {
   test("get(), set()") {

--- a/src/test/scala/shade/tests/MemcachedSuite.scala
+++ b/src/test/scala/shade/tests/MemcachedSuite.scala
@@ -1,15 +1,13 @@
 package shade.tests
 
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import scala.concurrent.ExecutionContext.Implicits.global
-import shade.testModels.{ContentPiece, Impression}
-import java.io.{ObjectOutputStream, ByteArrayOutputStream}
+import shade.testModels.{ ContentPiece, Impression }
+import java.io.{ ObjectOutputStream, ByteArrayOutputStream }
 import shade.memcached.FailureMode
 import scala.concurrent.duration._
 import scala.concurrent.Await
 import shade.TimeoutException
-
 
 class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
   implicit val timeout = 5.second
@@ -216,8 +214,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
       try {
         Await.result(seq, 20.seconds)
         fail("should throw exception")
-      }
-      catch {
+      } catch {
         case ex: TimeoutException =>
           assert(ex.getMessage === "some-key")
       }
@@ -243,8 +240,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
       try {
         Await.result(seq, 20.seconds)
         fail("should throw exception")
-      }
-      catch {
+      } catch {
         case ex: TimeoutException =>
           assert(ex.key === "some-key")
       }
@@ -283,7 +279,6 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
       assert(inBytes.get.length == byteArray.length)
     }
   }
-
 
   test("big-instance-2") {
     withCache("big-instance-2") { cache =>

--- a/src/test/scala/shade/tests/MemcachedTestHelpers.scala
+++ b/src/test/scala/shade/tests/MemcachedTestHelpers.scala
@@ -29,8 +29,7 @@ trait MemcachedTestHelpers extends MemcachedCodecs {
     val cache = new FakeMemcached(global)
     try {
       cb(cache)
-    }
-    finally {
+    } finally {
       cache.close()
     }
   }
@@ -40,8 +39,7 @@ trait MemcachedTestHelpers extends MemcachedCodecs {
 
     try {
       cb(cache)
-    }
-    finally {
+    } finally {
       cache.close()
     }
   }


### PR DESCRIPTION
Should address #3 

Also:
- Reshuffle included Generic Codec implicit hierarchy:
  - Create a GenericCodec trait to hold the catch all Any GenericCodec implicit
  - Make MemcachedCodecs trait extend BaseCodecs then GenericCodec; that way
    we maintain compatibility for existing users. If they're trying to serialise a Array[Byte], the new *identity* codec will get used due to implicit resolution semantics
  - MemcachedCodecs singleton extends MemcachedCodecs trait