### PR TITLE
Upgrade to a version of SBT-PGP that is compatible with SBT < 0.13.5+

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")


### PR DESCRIPTION
As per the official docs for the plugin (http://www.scala-sbt.org/sbt-pgp/)
we should be using v1.0.0