### PR TITLE
Downgrade Coveralls plugin version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
 services:
   - memcache
 script: "sbt clean coverage test"
-after_success: "sbt coveralls"
+after_success: "sbt coverageReport coveralls"
 cache:
   directories:
   - $HOME/.sbt/0.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,8 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
+// SBT-Scoverage version must be compatible with SBT-coveralls version below
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.3")
+// Upgrade when this issue is solved https://github.com/scoverage/sbt-coveralls/issues/73
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")


### PR DESCRIPTION
Currently the Travis job fails (https://travis-ci.org/alexandru/shade/jobs/97903369#L505)
to send coverage to Coveralls.io because of a bug in the plugin as mentioned in this
issue https://github.com/scoverage/sbt-coveralls/issues/73.

Scoverage also needs to be downgraded to match the working version of Coveralls.

