### PR TITLE
enable low-level optimization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "net.spy" % "spymemcached" % "2.11.7",
+  "net.spy" % "spymemcached" % "2.12.0",
   "org.slf4j" % "slf4j-api" % "1.7.13",
   "org.monifu" %% "monifu-core" % "1.0",
   "ch.qos.logback" % "logback-classic" % "1.1.3" % Test,

--- a/src/main/scala/shade/memcached/Configuration.scala
+++ b/src/main/scala/shade/memcached/Configuration.scala
@@ -24,7 +24,7 @@ import net.spy.memcached.ops.OperationQueueFactory
  * @param operationTimeout  is the default operation timeout; When the limit is reached, the
  *                          Future responses finish with Failure(TimeoutException)
  *
- * @param shouldOptimize    If true, low-level optimization is in effect.
+ * @param shouldOptimize    If true, optimization will collapse multiple sequential get ops.
  *
  * @param opQueueFactory    can be used to customize the operations queue,
  *                          i.e. the queue of operations waiting to be processed by SpyMemcached.

--- a/src/main/scala/shade/memcached/Configuration.scala
+++ b/src/main/scala/shade/memcached/Configuration.scala
@@ -24,6 +24,8 @@ import net.spy.memcached.ops.OperationQueueFactory
  * @param operationTimeout  is the default operation timeout; When the limit is reached, the
  *                          Future responses finish with Failure(TimeoutException)
  *
+ * @param shouldOptimize    If true, low-level optimization is in effect.
+ *
  * @param opQueueFactory    can be used to customize the operations queue,
  *                          i.e. the queue of operations waiting to be processed by SpyMemcached.
  *                          If `None`, the default SpyMemcached implementation (a bounded ArrayBlockingQueue) is used.
@@ -43,6 +45,7 @@ case class Configuration(
   protocol: Protocol.Value = Protocol.Binary,
   failureMode: FailureMode.Value = FailureMode.Retry,
   operationTimeout: FiniteDuration = 1.second,
+  shouldOptimize: Boolean = false,
   opQueueFactory: Option[OperationQueueFactory] = None,
   writeQueueFactory: Option[OperationQueueFactory] = None,
   readQueueFactory: Option[OperationQueueFactory] = None

--- a/src/main/scala/shade/memcached/MemcachedImpl.scala
+++ b/src/main/scala/shade/memcached/MemcachedImpl.scala
@@ -278,6 +278,7 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
         .setOpQueueFactory(config.opQueueFactory.orNull)
         .setReadOpQueueFactory(config.readQueueFactory.orNull)
         .setWriteOpQueueFactory(config.writeQueueFactory.orNull)
+        .setShouldOptimize(config.shouldOptimize)
 
       val withTimeout = config.operationTimeout match {
         case duration: FiniteDuration =>


### PR DESCRIPTION
I'd like to use [`ConnectionFactory.shouldOptimize()`](https://github.com/couchbase/spymemcached/blob/41cf86b39b0804cdb9bdf35574b7f8afbbef7102/src/main/java/net/spy/memcached/ConnectionFactory.java#L146-L149).