### PR TITLE
Apply format by scalariform

### DIFF
--- a/src/main/scala/shade/inmemory/InMemoryCache.scala
+++ b/src/main/scala/shade/inmemory/InMemoryCache.scala
@@ -259,14 +259,12 @@ private[inmemory] final class InMemoryCacheImpl(implicit ec: ExecutionContext) e
 
   private[this] case class CacheValue(
     value: Any,
-    expiresAt: Long
-  )
+    expiresAt: Long)
 
   private[this] case class CacheState(
     values: Map[String, CacheValue] = Map.empty,
     firstExpiry: Long = 0,
-    maintenancePromise: Promise[Int] = Promise[Int]()
-  )
+    maintenancePromise: Promise[Int] = Promise[Int]())
 
   private[this] val stateRef = AtomicAny(CacheState())
 }

--- a/src/main/scala/shade/memcached/Configuration.scala
+++ b/src/main/scala/shade/memcached/Configuration.scala
@@ -48,8 +48,7 @@ case class Configuration(
   shouldOptimize: Boolean = false,
   opQueueFactory: Option[OperationQueueFactory] = None,
   writeQueueFactory: Option[OperationQueueFactory] = None,
-  readQueueFactory: Option[OperationQueueFactory] = None
-)
+  readQueueFactory: Option[OperationQueueFactory] = None)
 
 object Protocol extends Enumeration {
   type Type = Value
@@ -62,5 +61,4 @@ object FailureMode extends Enumeration {
 
 case class AuthConfiguration(
   username: String,
-  password: String
-)
+  password: String)

--- a/src/test/scala/shade/testModels/Advertiser.scala
+++ b/src/test/scala/shade/testModels/Advertiser.scala
@@ -3,5 +3,4 @@ package shade.testModels
 case class Advertiser(
   id: Option[Int],
   name: Option[String],
-  serviceID: String
-)
+  serviceID: String)

--- a/src/test/scala/shade/testModels/ContentPiece.scala
+++ b/src/test/scala/shade/testModels/ContentPiece.scala
@@ -63,8 +63,7 @@ object ContentPiece {
     photo: String,
     title: Option[String],
     source: ContentSource,
-    tags: Vector[String]
-  ) extends ContentPiece
+    tags: Vector[String]) extends ContentPiece
 
   @SerialVersionUID(9785234918758324L)
   case class Title(
@@ -73,8 +72,7 @@ object ContentPiece {
     creator: String,
     title: String,
     source: ContentSource,
-    tags: Vector[String]
-  ) extends ContentPiece
+    tags: Vector[String]) extends ContentPiece
 
   @SerialVersionUID(9348538729520853L)
   case class Article(
@@ -86,8 +84,7 @@ object ContentPiece {
     excerptHtml: String,
     contentHtml: Option[String],
     source: ContentSource,
-    tags: Vector[String]
-  ) extends ContentPiece
+    tags: Vector[String]) extends ContentPiece
 }
 
 sealed trait ContentSource extends Serializable {

--- a/src/test/scala/shade/testModels/GeoIPLocation.scala
+++ b/src/test/scala/shade/testModels/GeoIPLocation.scala
@@ -9,5 +9,4 @@ case class GeoIPLocation(
   areaCode: Option[Int],
   postalCode: Option[String],
   region: Option[String],
-  dmaCode: Option[Int]
-)
+  dmaCode: Option[Int])

--- a/src/test/scala/shade/testModels/Impression.scala
+++ b/src/test/scala/shade/testModels/Impression.scala
@@ -6,5 +6,4 @@ case class Impression(
   servedOffers: Seq[Offer] = Seq.empty,
   requestCount: Int = 0,
   alreadyServed: Boolean = false,
-  clientVersion: Option[String] = None
-)
+  clientVersion: Option[String] = None)

--- a/src/test/scala/shade/testModels/Offer.scala
+++ b/src/test/scala/shade/testModels/Offer.scala
@@ -22,8 +22,7 @@ case class Offer(
     isDynamic: Boolean,
     isGlobal: Boolean,
 
-    countries: Seq[String]
-) {
+    countries: Seq[String]) {
 
   def uniqueToken = {
     val token = id.toString + "-" + advertiser.serviceID +
@@ -45,13 +44,11 @@ case class LiveDealInfo(
   uid: Option[String],
   expires: Option[Int],
   refreshToken: Option[Int],
-  searchKeyword: Option[String]
-)
+  searchKeyword: Option[String])
 
 case class OfferCreative(
   title: String,
   description: String,
   merchantName: Option[String],
   merchantPhone: Option[String],
-  htmlDescription: Option[String]
-)
+  htmlDescription: Option[String])

--- a/src/test/scala/shade/testModels/Session.scala
+++ b/src/test/scala/shade/testModels/Session.scala
@@ -10,6 +10,5 @@ case class Session(
   userIP: Option[String] = None,
   locationLat: Option[Float] = None,
   locationLon: Option[Float] = None,
-  countryCode: Option[String] = None
-)
+  countryCode: Option[String] = None)
 

--- a/src/test/scala/shade/testModels/UserInfo.scala
+++ b/src/test/scala/shade/testModels/UserInfo.scala
@@ -5,5 +5,4 @@ case class UserInfo(
   forwardedFor: String,
   via: String,
   agent: String,
-  geoip: Option[GeoIPLocation]
-)
+  geoip: Option[GeoIPLocation])


### PR DESCRIPTION
Some differences occurs by running `sbt clean test:compile` because of using sbt-scalariform.

I think these should be treated as default, but what do you think?