### PR TITLE
Set expiration time to 0 for infinite duration

### DIFF
--- a/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
+++ b/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
@@ -446,7 +446,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       else
         System.currentTimeMillis() / 1000 + seconds
     case _ =>
-      // infinite duration (set to 365 days)
-      System.currentTimeMillis() / 1000 + 31536000 // 60 * 60 * 24 * 365 -> 365 days in seconds
+      // infinite duration (set to 0)
+      0
   }
 }

--- a/src/test/scala/shade/tests/MemcachedSuite.scala
+++ b/src/test/scala/shade/tests/MemcachedSuite.scala
@@ -309,4 +309,16 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
       assert(cache.awaitGet[Impression](impression.uuid) === Some(impression))
     }
   }
+
+  test("infinite-duration") {
+    withCache("infinite-duration") { cache =>
+      assert(cache.awaitGet[Value]("hello") === None)
+
+      cache.awaitSet("hello", Value("world"), Duration.Inf)
+      assert(cache.awaitGet[Value]("hello") === Some(Value("world")))
+
+      Thread.sleep(5000)
+      assert(cache.awaitGet[Value]("hello") === Some(Value("world")))
+    }
+  }
 }


### PR DESCRIPTION
From memcached protocol:
```
- <exptime> is expiration time. If it's 0, the item never expires
  (although it may be deleted from the cache to make place for other
  items). If it's non-zero (either Unix time or offset in seconds from
  current time), it is guaranteed that clients will not be able to
  retrieve this item after the expiration time arrives (measured by
  server time).
```