### PR TITLE
Enable configuration of hash algorithm

### DIFF
--- a/src/main/scala/shade/memcached/Configuration.scala
+++ b/src/main/scala/shade/memcached/Configuration.scala
@@ -1,6 +1,7 @@
 package shade.memcached
 
 import net.spy.memcached.ops.OperationQueueFactory
+import net.spy.memcached.{ DefaultConnectionFactory, HashAlgorithm }
 
 import scala.concurrent.duration._
 
@@ -38,6 +39,8 @@ import scala.concurrent.duration._
  * @param writeQueueFactory can be used to customize the write queue,
  *                          i.e. the queue of operations waiting to be sent to Memcached by SpyMemcached.
  *                          If `None`, the default SpyMemcached implementation (an unbounded LinkedBlockingQueue) is used.
+ *
+ * @param hashAlgorithm     the method for hashing a cache key for server selection
  */
 case class Configuration(
   addresses: String,
@@ -49,7 +52,8 @@ case class Configuration(
   shouldOptimize: Boolean = false,
   opQueueFactory: Option[OperationQueueFactory] = None,
   writeQueueFactory: Option[OperationQueueFactory] = None,
-  readQueueFactory: Option[OperationQueueFactory] = None)
+  readQueueFactory: Option[OperationQueueFactory] = None,
+  hashAlgorithm: HashAlgorithm = DefaultConnectionFactory.DEFAULT_HASH)
 
 object Protocol extends Enumeration {
   type Type = Value

--- a/src/main/scala/shade/memcached/MemcachedImpl.scala
+++ b/src/main/scala/shade/memcached/MemcachedImpl.scala
@@ -279,6 +279,7 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
         .setReadOpQueueFactory(config.readQueueFactory.orNull)
         .setWriteOpQueueFactory(config.writeQueueFactory.orNull)
         .setShouldOptimize(config.shouldOptimize)
+        .setHashAlg(config.hashAlgorithm)
 
       val withTimeout = config.operationTimeout match {
         case duration: FiniteDuration =>


### PR DESCRIPTION
If using Shade to address a cluster of Memcache nodes shared with other clients, it's necessary to synchronize the algorithm mapping keys to nodes. The default spymemcached hash algorithm is based on Java's String.hashCode(), and generally not available on non-JVM platforms. This change allows the user to change the hash algorithm used to something with potentially more CPU overhead, but also more cross-platform availability.