### PR TITLE
Add server-side increment / decrement support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: scala
-sudo: false
+sudo: required
+dist: trusty
 scala:
   - 2.10.6
   - 2.11.7
 jdk:
-  - openjdk7
+  - oraclejdk7
   - oraclejdk8
 services:
-  - memcache
+  - docker
+before_install:
+  - sudo service memcached stop
+  - docker pull memcached
+  - docker run -d -p 127.0.0.1:11211:11211 memcached memcached
 script: "sbt clean coverage test"
 after_success: "sbt coverageReport coveralls"
 cache:
@@ -22,4 +27,3 @@ before_cache:
   - du -h -d 2 $HOME/.sbt/
   - find $HOME/.sbt -name "*.lock" -type f -delete
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
-

--- a/src/main/scala/shade/memcached/Memcached.scala
+++ b/src/main/scala/shade/memcached/Memcached.scala
@@ -94,6 +94,58 @@ trait Memcached extends java.io.Closeable {
   def getAndTransform[T](key: String, exp: Duration)(cb: Option[T] => T)(implicit codec: Codec[T]): Future[Option[T]]
 
   /**
+   * Atomically increments the given key by a non-negative integer amount
+   * and returns the new value.
+   *
+   * The value is stored as the ASCII decimal representation of a 64-bit
+   * unsigned integer.
+   *
+   * If the key does not exist and a default is provided, sets the value of the
+   * key to the provided default and expiry time.
+   *
+   * If the key does not exist and no default is provided, or if the key exists
+   * with a value that does not conform to the expected representation, the
+   * operation will fail.
+   *
+   * If the operation succeeds, it returns the new value of the key.
+   *
+   * Note that the default value is always treated as None when using the text
+   * protocol.
+   *
+   * The expiry time can be Duration.Inf (infinite duration).
+   */
+  def increment(key: String, by: Long, default: Option[Long], exp: Duration): Future[Long]
+
+  def awaitIncrement(key: String, by: Long, default: Option[Long], exp: Duration): Long =
+    Await.result(increment(key, by, default, exp), Duration.Inf)
+
+  /**
+   * Atomically decrements the given key by a non-negative integer amount
+   * and returns the new value.
+   *
+   * The value is stored as the ASCII decimal representation of a 64-bit
+   * unsigned integer.
+   *
+   * If the key does not exist and a default is provided, sets the value of the
+   * key to the provided default and expiry time.
+   *
+   * If the key does not exist and no default is provided, or if the key exists
+   * with a value that does not conform to the expected representation, the
+   * operation will fail.
+   *
+   * If the operation succeeds, it returns the new value of the key.
+   *
+   * Note that the default value is always treated as None when using the text
+   * protocol.
+   *
+   * The expiry time can be Duration.Inf (infinite duration).
+   */
+  def decrement(key: String, by: Long, default: Option[Long], exp: Duration): Future[Long]
+
+  def awaitDecrement(key: String, by: Long, default: Option[Long], exp: Duration): Long =
+    Await.result(decrement(key, by, default, exp), Duration.Inf)
+
+  /**
    * Shuts down the cache instance, performs any additional cleanups necessary.
    */
   def close(): Unit

--- a/src/main/scala/shade/memcached/MemcachedImpl.scala
+++ b/src/main/scala/shade/memcached/MemcachedImpl.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit
 import monifu.concurrent.Scheduler
 import net.spy.memcached.ConnectionFactoryBuilder.{ Protocol => SpyProtocol }
 import net.spy.memcached.auth.{ AuthDescriptor, PlainCallbackHandler }
+import net.spy.memcached.ops.Mutator
 import net.spy.memcached.{ FailureMode => SpyFailureMode, _ }
 import shade.memcached.internals.{ FailedResult, SuccessfulResult, _ }
 import shade.{ CancelledException, TimeoutException, UnhandledStatusException }
@@ -222,6 +223,64 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
   def close(): Unit = {
     instance.shutdown(3, TimeUnit.SECONDS)
   }
+
+  /**
+   * Atomically increments the given key by a non-negative integer amount
+   * and returns the new value.
+   *
+   * The value is stored as the ASCII decimal representation of a 64-bit
+   * unsigned integer.
+   *
+   * If the key does not exist and a default is provided, sets the value of the
+   * key to the provided default and expiry time.
+   *
+   * If the key does not exist and no default is provided, or if the key exists
+   * with a value that does not conform to the expected representation, the
+   * operation will fail.
+   *
+   * If the operation succeeds, it returns the new value of the key.
+   *
+   * Note that the default value is always treated as None when using the text
+   * protocol.
+   *
+   * The expiry time can be Duration.Inf (infinite duration).
+   */
+  def increment(key: String, by: Long, default: Option[Long], exp: Duration): Future[Long] =
+    instance.realAsyncMutate(withPrefix(key), by, Mutator.incr, default, exp, config.operationTimeout) map {
+      case SuccessfulResult(givenKey, value) =>
+        value
+      case failure: FailedResult =>
+        throwExceptionOn(failure)
+    }
+
+  /**
+   * Atomically decrements the given key by a non-negative integer amount
+   * and returns the new value.
+   *
+   * The value is stored as the ASCII decimal representation of a 64-bit
+   * unsigned integer.
+   *
+   * If the key does not exist and a default is provided, sets the value of the
+   * key to the provided default and expiry time.
+   *
+   * If the key does not exist and no default is provided, or if the key exists
+   * with a value that does not conform to the expected representation, the
+   * operation will fail.
+   *
+   * If the operation succeeds, it returns the new value of the key.
+   *
+   * Note that the default value is always treated as None when using the text
+   * protocol.
+   *
+   * The expiry time can be Duration.Inf (infinite duration).
+   */
+  def decrement(key: String, by: Long, default: Option[Long], exp: Duration): Future[Long] =
+    instance.realAsyncMutate(withPrefix(key), by, Mutator.decr, default, exp, config.operationTimeout) map {
+      case SuccessfulResult(givenKey, value) =>
+        value
+      case failure: FailedResult =>
+        throwExceptionOn(failure)
+    }
 
   private[this] def throwExceptionOn(failure: FailedResult) = failure match {
     case FailedResult(k, TimedOutStatus) =>

--- a/src/main/scala/shade/memcached/MemcachedImpl.scala
+++ b/src/main/scala/shade/memcached/MemcachedImpl.scala
@@ -247,7 +247,7 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
    */
   def increment(key: String, by: Long, default: Option[Long], exp: Duration): Future[Long] =
     instance.realAsyncMutate(withPrefix(key), by, Mutator.incr, default, exp, config.operationTimeout) map {
-      case SuccessfulResult(givenKey, value) =>
+      case SuccessfulResult(_, value) =>
         value
       case failure: FailedResult =>
         throwExceptionOn(failure)
@@ -276,7 +276,7 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
    */
   def decrement(key: String, by: Long, default: Option[Long], exp: Duration): Future[Long] =
     instance.realAsyncMutate(withPrefix(key), by, Mutator.decr, default, exp, config.operationTimeout) map {
-      case SuccessfulResult(givenKey, value) =>
+      case SuccessfulResult(_, value) =>
         value
       case failure: FailedResult =>
         throwExceptionOn(failure)

--- a/src/test/scala/shade/tests/FakeMemcachedSuite.scala
+++ b/src/test/scala/shade/tests/FakeMemcachedSuite.scala
@@ -260,6 +260,18 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
     }
   }
 
+  test("decrement-underflow") {
+    withFakeMemcached { cache =>
+      assert(cache.awaitDecrement("hello", 1, Some(1), 1.minute) === 1)
+
+      assert(cache.awaitDecrement("hello", 1, None, 1.minute) === 0)
+
+      assert(cache.awaitDecrement("hello", 1, None, 1.minute) === 0)
+
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("0"))
+    }
+  }
+
   test("big-instance-1") {
     withFakeMemcached { cache =>
       val impression = shade.testModels.bigInstance

--- a/src/test/scala/shade/tests/FakeMemcachedSuite.scala
+++ b/src/test/scala/shade/tests/FakeMemcachedSuite.scala
@@ -215,6 +215,25 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
     }
   }
 
+  test("increment-decrement-delta") {
+    withFakeMemcached { cache =>
+      assert(cache.awaitGet[Int]("hello") === None)
+
+      cache.awaitSet("hello", "123", 1.second)(StringBinaryCodec)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
+
+      cache.awaitIncrement("hello", 5, None, 1.second)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("128"))
+
+      cache.awaitDecrement("hello", 5, None, 1.second)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
+
+      Thread.sleep(3000)
+
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === None)
+    }
+  }
+
   test("increment-default") {
     withFakeMemcached { cache =>
       assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === None)
@@ -228,6 +247,16 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
       Thread.sleep(3000)
 
       assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === None)
+    }
+  }
+
+  test("increment-overflow") {
+    withFakeMemcached { cache =>
+      assert(cache.awaitIncrement("hello", 1, Some(Long.MaxValue), 1.minute) === Long.MaxValue)
+
+      assert(cache.awaitIncrement("hello", 1, None, 1.minute) === Long.MinValue)
+
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("9223372036854775808"))
     }
   }
 

--- a/src/test/scala/shade/tests/MemcachedSuite.scala
+++ b/src/test/scala/shade/tests/MemcachedSuite.scala
@@ -313,6 +313,18 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
     }
   }
 
+  test("decrement-underflow") {
+    withCache("increment-underflow") { cache =>
+      assert(cache.awaitDecrement("hello", 1, Some(1), 1.minute) === 1)
+
+      assert(cache.awaitDecrement("hello", 1, None, 1.minute) === 0)
+
+      assert(cache.awaitDecrement("hello", 1, None, 1.minute) === 0)
+
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("0"))
+    }
+  }
+
   test("vector-inherited-case-classes") {
     withCache("vector-inherited-case-classes") { cache =>
       val content = shade.testModels.contentSeq

--- a/src/test/scala/shade/tests/MemcachedSuite.scala
+++ b/src/test/scala/shade/tests/MemcachedSuite.scala
@@ -249,6 +249,41 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
     }
   }
 
+  test("increment-decrement") {
+    withCache("increment-decrement") { cache =>
+      assert(cache.awaitGet[Int]("hello") === None)
+
+      cache.awaitSet("hello", "123", 1.second)(StringBinaryCodec)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
+
+      cache.awaitIncrement("hello", 1, None, 1.second)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("124"))
+
+      cache.awaitDecrement("hello", 1, None, 1.second)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
+
+      Thread.sleep(3000)
+
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === None)
+    }
+  }
+
+  test("increment-default") {
+    withCache("increment-default") { cache =>
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === None)
+
+      cache.awaitIncrement("hello", 1, Some(0), 1.second)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("0"))
+
+      cache.awaitIncrement("hello", 1, Some(0), 1.second)
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("1"))
+
+      Thread.sleep(3000)
+
+      assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === None)
+    }
+  }
+
   test("vector-inherited-case-classes") {
     withCache("vector-inherited-case-classes") { cache =>
       val content = shade.testModels.contentSeq


### PR DESCRIPTION
Memcache protocol and spymemcached support server-side atomic increment and decrement of keys with a specific format (ASCII-string of the decimal representation of an integer). This should help performance over client-managed CAS, especially for highly contented use cases.