### PR TITLE
Complete failed status translations with tryComplete

### DIFF
--- a/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
+++ b/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
@@ -445,9 +445,9 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
     spyMemcachedStatus: OperationStatus,
     key: String,
     result: MutablePartialResult[_])(handler: PartialFunction[Status, Unit]): Unit = {
-    val status = statusTranslation.applyOrElse(spyMemcachedStatus, UnhandledStatus.apply)
+    val status = statusTranslation.applyOrElse(spyMemcachedStatus, UnhandledStatus.fromSpyMemcachedStatus)
     handler.applyOrElse(status, {
-      case UnhandledStatus(underlyingStatus) => result.tryComplete(Failure(new UnhandledStatusException(s"${underlyingStatus.getClass}(${underlyingStatus.getMessage})")))
+      case UnhandledStatus(statusClass, statusMsg) => result.tryComplete(Failure(new UnhandledStatusException(s"$statusClass($statusMsg)")))
       // nothing
       case failure =>
         result.tryComplete(Success(FailedResult(key, failure)))

--- a/src/main/scala/shade/memcached/internals/Status.scala
+++ b/src/main/scala/shade/memcached/internals/Status.scala
@@ -1,5 +1,7 @@
 package shade.memcached.internals
 
+import net.spy.memcached.ops.OperationStatus
+
 sealed trait Status
 case object TimedOutStatus extends Status
 case object CancelledStatus extends Status
@@ -10,3 +12,4 @@ case object CASObserveErrorInArgs extends Status
 case object CASObserveModified extends Status
 case object CASObserveTimeout extends Status
 case object IllegalCompleteStatus extends Status
+case class UnhandledStatus(underlyingStatus: OperationStatus) extends Status

--- a/src/main/scala/shade/memcached/internals/Status.scala
+++ b/src/main/scala/shade/memcached/internals/Status.scala
@@ -1,8 +1,9 @@
 package shade.memcached.internals
 
 import net.spy.memcached.ops.OperationStatus
+import scala.language.existentials
 
-sealed trait Status
+sealed trait Status extends Product with Serializable
 case object TimedOutStatus extends Status
 case object CancelledStatus extends Status
 case object CASExistsStatus extends Status
@@ -12,4 +13,13 @@ case object CASObserveErrorInArgs extends Status
 case object CASObserveModified extends Status
 case object CASObserveTimeout extends Status
 case object IllegalCompleteStatus extends Status
-case class UnhandledStatus(underlyingStatus: OperationStatus) extends Status
+
+object UnhandledStatus {
+
+  /**
+   * Builds a serialisable UnhandledStatus from a given [[OperationStatus]] from SpyMemcached
+   */
+  def fromSpyMemcachedStatus(spyStatus: OperationStatus): UnhandledStatus = UnhandledStatus(spyStatus.getClass, spyStatus.getMessage)
+}
+
+final case class UnhandledStatus(statusClass: Class[_], message: String) extends Status


### PR DESCRIPTION
In reference to @alexandru's [comment](https://github.com/alexandru/shade/pull/38#discussion_r63824225) in #38 , try to complete the future when faced with untranslatable statuses instead of throwing.

Also:

- Turn the PartialFunction definition into a val because it is constant
- Add a new Status, UnhandledStatus for holding untranslatable SpyMemcached OperationStatuses