### PR TITLE
Introduce JMH Benchmarks

### DIFF
--- a/benchmarking/src/main/scala/shade/benchmarks/ExistingKeyOps.scala
+++ b/benchmarking/src/main/scala/shade/benchmarks/ExistingKeyOps.scala
@@ -1,0 +1,33 @@
+package shade.benchmarks
+
+import org.openjdk.jmh.annotations.{Benchmark, Setup}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.concurrent.duration._
+
+class ExistingKeyOps extends MemcachedBase {
+
+  val key: String = "existing"
+  val duration: FiniteDuration = 1.day
+
+  @Setup
+  def prepare(): Unit = {
+    memcached.set(key, 10L, duration)
+  }
+
+  @Benchmark
+  def get(bh: Blackhole): Unit = bh.consume {
+    memcached.awaitGet[String](key)
+  }
+
+  @Benchmark
+  def set(bh: Blackhole): Unit =  bh.consume{
+    memcached.awaitSet(key, 100L, duration)
+  }
+
+  @Benchmark
+  def delete(bh: Blackhole): Unit = bh.consume {
+    memcached.awaitDelete(key)
+  }
+
+}

--- a/benchmarking/src/main/scala/shade/benchmarks/IncDecrOps.scala
+++ b/benchmarking/src/main/scala/shade/benchmarks/IncDecrOps.scala
@@ -1,0 +1,28 @@
+package shade.benchmarks
+
+
+import scala.concurrent.duration._
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+class IncDecrOps extends MemcachedBase {
+
+  val key: String = "incr-decr"
+  val duration: FiniteDuration = 1.day
+
+  @Setup
+  def prepare(): Unit = {
+    memcached.awaitSet(key, 1E10.toLong.toString, duration)
+  }
+
+  @Benchmark
+  def increment(bh: Blackhole): Unit = bh.consume{
+    memcached.awaitIncrement(key, 1L, None, duration)
+  }
+
+  @Benchmark
+  def decrement(bh: Blackhole): Unit = bh.consume {
+    memcached.awaitDecrement(key, 1L, None, duration)
+  }
+
+}

--- a/benchmarking/src/main/scala/shade/benchmarks/MemcachedBase.scala
+++ b/benchmarking/src/main/scala/shade/benchmarks/MemcachedBase.scala
@@ -1,0 +1,32 @@
+package shade.benchmarks
+
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import shade.memcached.{Configuration, FailureMode, Memcached, Protocol}
+
+import scala.concurrent.ExecutionContext.global
+import scala.concurrent.duration._
+
+/**
+  * Base class for benchmarks that need an instance of [[Memcached]]
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+abstract class MemcachedBase {
+
+  val memcached: Memcached = {
+    val defaultConfig = Configuration(
+      addresses = "127.0.0.1:11211",
+      authentication = None,
+      keysPrefix = Some("my-benchmarks"),
+      protocol = Protocol.Binary,
+      failureMode = FailureMode.Retry,
+      operationTimeout = 15.seconds
+    )
+    Memcached(defaultConfig)(global)
+  }
+
+}

--- a/benchmarking/src/main/scala/shade/benchmarks/NonExistingKeyOps.scala
+++ b/benchmarking/src/main/scala/shade/benchmarks/NonExistingKeyOps.scala
@@ -1,0 +1,29 @@
+package shade.benchmarks
+
+import scala.concurrent.duration._
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+class NonExistingKeyOps extends MemcachedBase {
+
+  val key: String = "non-existing"
+  val duration: FiniteDuration = 1.day
+
+  @Setup
+  def prepare(): Unit = memcached.delete(key)
+
+  @Benchmark
+  def get(bh: Blackhole): Unit = bh.consume {
+    memcached.awaitGet[String](key)
+  }
+
+  @Benchmark
+  def set(bh: Blackhole): Unit = bh.consume {
+    memcached.awaitSet(key, 1L, duration)
+  }
+
+  @Benchmark
+  def delete(bh: Blackhole): Unit = bh.consume {
+    memcached.awaitDelete(key)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -106,3 +106,12 @@ pomExtra in ThisBuild :=
         <url>https://www.bionicspirit.com/</url>
       </developer>
     </developers>
+
+// Multi-project-related
+
+lazy val root = project in file(".")
+
+lazy val benchmarking = (project in file("benchmarking"))
+  .enablePlugins(JmhPlugin)
+  .settings(libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.21")
+  .dependsOn(root)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 
 // Upgrade when this issue is solved https://github.com/scoverage/sbt-coveralls/issues/73
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")

--- a/run-benchmarks
+++ b/run-benchmarks
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# We need to explicitly set scala version because we get java.lang.NoSuchMethodError
+# Perhaps caused by SBT-JMH being on Scala 2.10.x
+sbt ++2.11.8 clean benchmarking/'jmh:run -i 10 -wi 10 -f3 -t 1'


### PR DESCRIPTION
Part of #33 involves adding JMH-backed benchmarks so we can keep track of performance. This PR aims to introduce some.

To run benchmarks:

`$ ./run-benchmarks`

Changes:
- Add a subproject for running benchmarks called 'benchmarks'
- Add an SBT Plugin dependency on SBT-JMH
- Add tests for the blocking actions exposed by Shade.Memcached
- Add a script for running the benchmarks
